### PR TITLE
fixing github.com/openslo/oslo url

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -41,7 +41,7 @@ params:
   - title: Get involved
     url: https://www.github.com/openslo/openslo
   - title: Oslo
-    url: https://www.github.com/openslo/olso
+    url: https://www.github.com/openslo/oslo
   - title: Join our Slack
     url: https://github.com/OpenSLO/OpenSLO/blob/initial-draft/CONTRIBUTING.md#slack
   - title: Demo Video


### PR DESCRIPTION
it was olso and directing to a 404