### PR TITLE
add blog post with recent meeting summary

### DIFF
--- a/content/blog/OpenSLO Project Meeting: February 2024.md
+++ b/content/blog/OpenSLO Project Meeting: February 2024.md
@@ -1,0 +1,32 @@
+---
+title: "OpenSLO Project Meeting: February 2024"
+date: 2024-02-21T13:00:00+02:00
+draft: false
+author: Pawel Rusakiewicz
+cover: /images/openslo_logo.svg
+---
+First community meeting in 2024
+
+## Summary of Meeting
+
+During the meeting, several agenda items were discussed and decisions were made regarding the OpenSLO project.
+
+1. **Source of Truth for OpenSLO manifest**:
+   The group decided to use Go structs as the source of truth for the OpenSLO manifest. This decision was made to ensure more control over validation. The plan is to generate JSON Schema/CRDs based on Go structs.
+
+2. **Labels Support**:
+   Labels support is to be extended for all objects' metadata, including adding labels to Objective and supporting multiple alert conditions.
+
+3. **Compatibility and Templating**:
+   The team aims for full compatibility with Kubernetes CRDs and plans to introduce templating to the OpenSLO spec. They also discussed adding the concept of "medleys" of SLOs and implementing a plugin system for Oslo.
+
+4. **Conversion Removal**:
+   The decision was made to remove the conversion entirely and extend Oslo documentation on the usage of annotations for vendor-specific conversions. The focus will be on improving the SDK instead of expanding Oslo's responsibilities.
+
+5. **Action Items**:
+   Several action items were noted, including documenting new use cases of OpenSLO, reaching out to Grafana regarding an issue, ensuring full Kubernetes compatibility, and considering bringing OpenSLO under CNCF's umbrella.
+
+The next meeting is scheduled for a month later. Precise date TBD.
+
+### Meeting recording
+{{< youtube zxRa2sWz0Ag >}}

--- a/content/blog/OpenSLO Project Meeting: February 2024.md
+++ b/content/blog/OpenSLO Project Meeting: February 2024.md
@@ -17,13 +17,10 @@ During the meeting, several agenda items were discussed and decisions were made 
 2. **Labels Support**:
    Labels support is to be extended for all objects' metadata, including adding labels to Objective and supporting multiple alert conditions.
 
-3. **Compatibility and Templating**:
-   The team aims for full compatibility with Kubernetes CRDs and plans to introduce templating to the OpenSLO spec. They also discussed adding the concept of "medleys" of SLOs and implementing a plugin system for Oslo.
-
-4. **Conversion Removal**:
+3. **Conversion Removal**:
    The decision was made to remove the conversion entirely and extend Oslo documentation on the usage of annotations for vendor-specific conversions. The focus will be on improving the SDK instead of expanding Oslo's responsibilities.
 
-5. **Action Items**:
+4. **Action Items**:
    Several action items were noted, including documenting new use cases of OpenSLO, reaching out to Grafana regarding an issue, ensuring full Kubernetes compatibility, and considering bringing OpenSLO under CNCF's umbrella.
 
 The next meeting is scheduled for a month later. Precise date TBD.

--- a/content/blog/OpenSLO Project Meeting: February 2024.md
+++ b/content/blog/OpenSLO Project Meeting: February 2024.md
@@ -23,7 +23,7 @@ During the meeting, several agenda items were discussed and decisions were made 
 4. **Action Items**:
    Several action items were noted, including documenting new use cases of OpenSLO, ensuring full Kubernetes compatibility, and considering bringing OpenSLO under CNCF's umbrella.
 
-The next meeting is scheduled for a month later. Precise date TBD.
+The next meeting is scheduled the next month. Precise date TBD.
 
 ### Meeting recording
 {{< youtube zxRa2sWz0Ag >}}

--- a/content/blog/OpenSLO Project Meeting: February 2024.md
+++ b/content/blog/OpenSLO Project Meeting: February 2024.md
@@ -15,7 +15,7 @@ During the meeting, several agenda items were discussed and decisions were made 
    The group decided to use Go structs as the source of truth for the OpenSLO manifest. This decision was made to ensure more control over validation. The plan is to generate JSON Schema/CRDs based on Go structs.
 
 2. **Labels Support**:
-   Labels support is to be extended for all objects' metadata, including adding labels to Objective and supporting multiple alert conditions.
+   Labels support is to be extended for all objects' metadata, including adding labels to Objective.
 
 3. **Conversion Removal**:
    The decision was made to remove the conversion entirely and extend Oslo documentation on the usage of annotations for vendor-specific conversions. The focus will be on improving the SDK instead of expanding Oslo's responsibilities.

--- a/content/blog/OpenSLO Project Meeting: February 2024.md
+++ b/content/blog/OpenSLO Project Meeting: February 2024.md
@@ -21,7 +21,7 @@ During the meeting, several agenda items were discussed and decisions were made 
    The decision was made to remove the conversion entirely and extend Oslo documentation on the usage of annotations for vendor-specific conversions. The focus will be on improving the SDK instead of expanding Oslo's responsibilities.
 
 4. **Action Items**:
-   Several action items were noted, including documenting new use cases of OpenSLO, reaching out to Grafana regarding an issue, ensuring full Kubernetes compatibility, and considering bringing OpenSLO under CNCF's umbrella.
+   Several action items were noted, including documenting new use cases of OpenSLO, ensuring full Kubernetes compatibility, and considering bringing OpenSLO under CNCF's umbrella.
 
 The next meeting is scheduled for a month later. Precise date TBD.
 

--- a/content/blog/OpenSLO Project Meeting: February 2024.md
+++ b/content/blog/OpenSLO Project Meeting: February 2024.md
@@ -17,7 +17,7 @@ During the meeting, several agenda items were discussed and decisions were made 
 2. **Labels Support**:
    Labels support is to be extended for all objects' metadata, including adding labels to Objective.
 
-3. **Conversion Removal**:
+3. **Oslo Conversion Removal**:
    The decision was made to remove the conversion entirely and extend Oslo documentation on the usage of annotations for vendor-specific conversions. The focus will be on improving the SDK instead of expanding Oslo's responsibilities.
 
 4. **Action Items**:

--- a/content/blog/OpenSLO Project Meeting: February 2024.md
+++ b/content/blog/OpenSLO Project Meeting: February 2024.md
@@ -18,7 +18,7 @@ During the meeting, several agenda items were discussed and decisions were made 
    Labels support is to be extended for all objects' metadata, including adding labels to Objective.
 
 3. **Oslo Conversion Removal**:
-   The decision was made to remove the conversion entirely and extend Oslo documentation on the usage of annotations for vendor-specific conversions. The focus will be on improving the SDK instead of expanding Oslo's responsibilities.
+   The decision was made to remove the conversion entirely and extend [oslo](https://github.com/openslo/oslo) documentation on the usage of annotations for vendor-specific conversions. The focus will be on improving the SDK instead of expanding [oslo's](https://github.com/openslo/oslo) responsibilities.
 
 4. **Action Items**:
    Several action items were noted, including documenting new use cases of OpenSLO, ensuring full Kubernetes compatibility, and considering bringing OpenSLO under CNCF's umbrella.


### PR DESCRIPTION
## Title: Add Meeting Summary as Hugo Article

### Description:
This pull request adds a new Hugo article based on the meeting summary markdown file. The meeting summary outlines the discussions and decisions made during the OpenSLO project meeting. By adding this as a Hugo article, it will be accessible through the website, providing easy access to project updates and decisions for team members and stakeholders. This article will enhance communication and transparency within the project.

### Changes:
- Added a new Markdown file containing the meeting summary.
- Created a new Hugo article using the meeting summary content.